### PR TITLE
Use base16-builder-go to automatically generate colorschemes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @base16-project/gtk-flatcolor

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest base16 colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest base16-project colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # base16-gtk-flatcolor
-This is a [Base16](https://github.com/chriskempson/base16) template for [FlatColor](https://github.com/jasperro/FlatColor), a gtk3 theme by jasperro and deviantfero,
+This is a [Base16](https://github.com/base16-project/home) template for [FlatColor](https://github.com/jasperro/FlatColor), a gtk3 theme by jasperro and deviantfero,
 
 ## Usage
 First download FlatColor theme from jasperro's repo to your .themes folder:


### PR DESCRIPTION
- Add feature where base16-builder-go is automatically run by a github action once a week to generate the colorschemes.
- Add codeowners file to automatically tag base16-termite maintainers when a PR or issue is created